### PR TITLE
Change TESTS_ENVIRONMENT to LOG_COMPILER in all Makefile.am files

### DIFF
--- a/src/add_field/Makefile.am
+++ b/src/add_field/Makefile.am
@@ -13,5 +13,5 @@ man1_MANS = add_field.1
 add_field.1 : args.tab
 	../bin/genman.pl args.tab > $@
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf

--- a/src/aggregate/Makefile.am
+++ b/src/aggregate/Makefile.am
@@ -8,7 +8,7 @@ aggregate_SOURCES = aggregate.c aggregate.h $(BUILT_SOURCES)
 
 aggregate_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/aggregate2/Makefile.am
+++ b/src/aggregate2/Makefile.am
@@ -8,7 +8,7 @@ aggregate2_SOURCES = aggregate2.c $(BUILT_SOURCES)
 
 aggregate2_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/calcfield/Makefile.am
+++ b/src/calcfield/Makefile.am
@@ -6,7 +6,7 @@ calcfield: calcfield.in Makefile
 				-I$(srcdir)/../perllib hackery.m4 $< crush_version.pl > $@
 	chmod +x $@
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 EXTRA_DIST = args.tab calcfield.in test.conf \

--- a/src/convdate/Makefile.am
+++ b/src/convdate/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = convdate
 convdate_SOURCES = convdate.c convdate.h $(BUILT_SOURCES)
 convdate_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/csvformat/Makefile.am
+++ b/src/csvformat/Makefile.am
@@ -10,7 +10,7 @@ csvformat: csvformat.in Makefile
 				-I$(srcdir)/../perllib hackery.m4 $< crush_version.pl > $@
 	chmod +x $@
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 man1_MANS = csvformat.1

--- a/src/cutfield/Makefile.am
+++ b/src/cutfield/Makefile.am
@@ -9,7 +9,7 @@ cutfield_LDADD = ../libcrush/libcrush.la
 
 CLEANFILES = $(BUILT_SOURCES)
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 EXTRA_DIST = args.tab test.conf \

--- a/src/dbstream/Makefile.am
+++ b/src/dbstream/Makefile.am
@@ -9,7 +9,7 @@ dbstream: dbstream.in Makefile
 				-I$(srcdir)/../perllib hackery.m4 $< crush_version.pl > $@
 	chmod +x $@
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 man1_MANS = dbstream.1
 dbstream.1 : args.tab

--- a/src/deltaforce/Makefile.am
+++ b/src/deltaforce/Makefile.am
@@ -8,7 +8,7 @@ deltaforce_SOURCES = deltaforce.c deltaforce.h $(BUILT_SOURCES)
 
 deltaforce_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/fieldsplit/Makefile.am
+++ b/src/fieldsplit/Makefile.am
@@ -8,7 +8,7 @@ fieldsplit_SOURCES = fieldsplit.c $(BUILT_SOURCES)
 
 fieldsplit_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)
@@ -16,7 +16,7 @@ CLEANFILES = $(BUILT_SOURCES)
 EXTRA_DIST = args.tab test.conf \
              test/test_001.sh test/001-transform-key.txt test/002-data.txt \
              test/001/2008-01.expected test/001/2008-02.expected \
-             test/test_002.sh test/002 \
+             test/test_002.sh \
              test/test_003.sh test/003/2008-01-29.expected \
              test/003/2008-02-01.expected \
              test/003/2008-02-09.expected \

--- a/src/filterkeys/Makefile.am
+++ b/src/filterkeys/Makefile.am
@@ -6,7 +6,7 @@ BUILT_SOURCES = main.c usage.c filterkeys_main.h
 bin_PROGRAMS = filterkeys
 filterkeys_SOURCES = filterkeys.c filterkeys.h $(BUILT_SOURCES)
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 filterkeys_LDADD = ../libcrush/libcrush.la

--- a/src/find_not_processed/test.sh
+++ b/src/find_not_processed/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 has_error=0
-ls . | grep -v test.sh > logfile.tmp
+(ls . | grep -v test.sh; echo -e "test.sh.log\ntest.sh.trs") > logfile.tmp
 echo logfile.tmp >> logfile.tmp
 
 f=`./find_not_processed -l logfile.tmp -d . -g '*'`

--- a/src/funiq/Makefile.am
+++ b/src/funiq/Makefile.am
@@ -6,7 +6,7 @@ $(BUILT_SOURCES) : args.tab
 bin_PROGRAMS = funiq
 funiq_SOURCES = funiq.c $(BUILT_SOURCES)
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/grepfield/Makefile.am
+++ b/src/grepfield/Makefile.am
@@ -6,7 +6,7 @@ BUILT_SOURCES = main.c usage.c grepfield_main.h
 bin_PROGRAMS = grepfield
 grepfield_SOURCES = grepfield.c grepfield.h $(BUILT_SOURCES)
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 grepfield_LDADD = ../libcrush/libcrush.la

--- a/src/hashjoin/Makefile.am
+++ b/src/hashjoin/Makefile.am
@@ -8,7 +8,7 @@ hashjoin_SOURCES = hashjoin.c $(BUILT_SOURCES)
 
 hashjoin_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/indexof/Makefile.am
+++ b/src/indexof/Makefile.am
@@ -6,7 +6,7 @@ $(BUILT_SOURCES) : args.tab
 bin_PROGRAMS = indexof
 indexof_SOURCES = indexof.c indexof.h $(BUILT_SOURCES)
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/mergekeys/Makefile.am
+++ b/src/mergekeys/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = mergekeys
 mergekeys_SOURCES = mergekeys.c mergekeys.h $(BUILT_SOURCES)
 mergekeys_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/pivot/Makefile.am
+++ b/src/pivot/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = pivot
 pivot_SOURCES = pivot.c $(BUILT_SOURCES)
 pivot_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/reorder/Makefile.am
+++ b/src/reorder/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = reorder
 reorder_SOURCES = reorder.c reorder.h $(BUILT_SOURCES)
 reorder_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/subtotal/Makefile.am
+++ b/src/subtotal/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = subtotal
 subtotal_SOURCES = subtotal.c $(BUILT_SOURCES)
 subtotal_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/src/translate_field/Makefile.am
+++ b/src/translate_field/Makefile.am
@@ -15,5 +15,5 @@ man1_MANS = translate_field.1
 translate_field.1 : args.tab
 	../bin/genman.pl args.tab > $@
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf

--- a/src/truncfield/Makefile.am
+++ b/src/truncfield/Makefile.am
@@ -7,7 +7,7 @@ bin_PROGRAMS = truncfield
 truncfield_SOURCES = truncfield.c $(BUILT_SOURCES)
 truncfield_LDADD = ../libcrush/libcrush.la
 
-TESTS_ENVIRONMENT = $(top_srcdir)/src/bin/testharness.sh
+LOG_COMPILER = $(top_srcdir)/src/bin/testharness.sh
 TESTS = test.conf
 
 CLEANFILES = $(BUILT_SOURCES)


### PR DESCRIPTION
Changes required for getting tests to run correctly with automake 1.13(ish) and newer.